### PR TITLE
adding oauth2client param to be used after salesforce-requests-oauthlib #7 is fixed

### DIFF
--- a/src/salesforce_streaming_client/__init__.py
+++ b/src/salesforce_streaming_client/__init__.py
@@ -94,6 +94,7 @@ class SalesforceStreamingClient(BayeuxClient):
                  password=None,
                  ignore_cached_refresh_tokens=False,
                  version=None,
+                 oauth2client=None,
                  replay_client_id=None,
                  cleanup_datadir=True):
 
@@ -141,7 +142,8 @@ class SalesforceStreamingClient(BayeuxClient):
             local_server_settings=local_server_settings,
             password=password,
             ignore_cached_refresh_tokens=ignore_cached_refresh_tokens,
-            version=version
+            version=version,
+            oauth2client=oauth2client
         )
 
         super(SalesforceStreamingClient, self).__init__(


### PR DESCRIPTION
adding oauth2client parameter to be used after https://github.com/SalesforceFoundation/salesforce-requests-oauthlib/issues/7 is fixed